### PR TITLE
docs: remove reference to deleted DEVELOPMENT_PRINCIPLES.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,6 @@ This is a **planned but not yet implemented** MCP server with the following inte
 - `README.md` - Comprehensive project documentation
 - `prd.md` - Product requirements document  
 - `spec.md` - Technical specifications
-- `DEVELOPMENT_PRINCIPLES.md` - Development methodology (now also in .cursor/rules/)
 - `.cursor/rules/` - Code philosophy, development principles, and commit standards
 
 ### Next Steps for Implementation


### PR DESCRIPTION
Fixes #3 - Removed outdated reference to DEVELOPMENT_PRINCIPLES.md from CLAUDE.md after the file was deleted.

Generated with [Claude Code](https://claude.ai/code)