### PR TITLE
chore(guardrails): enforce PR-only workflow and add zh STDIO smoke CI

### DIFF
--- a/.cursor/rules/development-principles.mdc
+++ b/.cursor/rules/development-principles.mdc
@@ -1,10 +1,36 @@
+# Development Principles (Augment)
+
+## Main protection & PR-only workflow
+
+- Do not commit/push directly to `main`
+- All changes must go through feature branches and Pull Requests
+- Enforce via GitHub Branch Protection Rules:
+  - Require PR before merge; code owner reviews required
+  - Require status checks (build, test, lint, STDIO zh smoke)
+  - Require branch up to date with base before merging
+  - Restrict who can push to `main` (allow only GitHub Apps e.g. github-actions)
+  - Disallow force pushes and deletions
+
+## Repository hygiene
+
+- CODEOWNERS defines mandatory reviewers per path
+- PR template must include risks and rollback plan
+- Conventional commits for consistency
+- CI should fail on direct push to `main` (educational guard)
+
+## Rationale
+
+- Small batches and reversible design (see Universal Development Principles)
+- Ensures peer review, traceability, and stable mainline
+
 ---
 description: Universal development methodology and principles for rapid, effective software delivery with continuous learning and improvement
 globs:
+- '**/*'
 alwaysApply: true
 ---
 
-# Universal Development Principles
+## Universal Development Principles
 
 ## Core Philosophy
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Require review from owners before merge
+# Adjust handles to your team as needed
+
+*       @lis186
+src/**  @lis186
+scripts/** @lis186
+.github/** @lis186
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# Pull Request
+
+## Summary
+
+Describe what this PR changes and why.
+
+## Checklist
+
+- [ ] Included tests or smoke scripts where applicable
+- [ ] Updated docs/README where needed
+- [ ] No direct commits to `main`; branch and PR only
+- [ ] Verified `npm run test:stdio-smoke` or `npm run test:stdio-zh`
+
+## Risks / Rollback
+
+- Risk: 
+- Rollback plan: Revert PR via GitHub UI
+
+## Screenshots / Logs (optional)

--- a/.github/workflows/prevent-direct-main-push.yml
+++ b/.github/workflows/prevent-direct-main-push.yml
@@ -1,0 +1,18 @@
+name: Prevent direct main push (educational)
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  block-direct-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if not GitHub Actions bot
+        run: |
+          if [ "${{ github.actor }}" != "github-actions[bot]" ]; then
+            echo "Direct pushes to main are not allowed. Please use PRs." >&2
+            exit 1
+          fi
+          echo "Push by GitHub Actions bot allowed."
+

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -13,16 +13,22 @@ fi
 echo "Applying branch protection to $REPO: main"
 
 # Basic PR requirements
+# IMPORTANT: Status check names must match the actual check run contexts.
+# For GitHub Actions, it is typically "<workflow name> / <job id>".
+# Our workflow is named "STDIO zh smoke" and job id is "stdio-zh-smoke".
+REQUIRED_CHECKS='["STDIO zh smoke / stdio-zh-smoke"]'
+
 gh api -X PUT \
   -H "Accept: application/vnd.github+json" \
   repos/$REPO/branches/main/protection \
   -f required_status_checks.strict=true \
-  --raw-field required_status_checks.contexts='["build","test","STDIO zh smoke"]' \
+  --raw-field required_status_checks.contexts=${REQUIRED_CHECKS} \
   -f enforce_admins=true \
   -f required_pull_request_reviews.dismiss_stale_reviews=true \
   -f required_pull_request_reviews.require_code_owner_reviews=true \
   -f required_pull_request_reviews.required_approving_review_count=1 \
-  -f restrictions=''
+  -f allow_deletions=false \
+  -f allow_force_pushes=false
 
 echo "Restricting direct push to main (allow only GitHub Actions)"
 gh api -X PATCH \

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/setup-branch-protection.sh <owner/repo>
+# Requires: gh auth login
+
+REPO=${1:-}
+if [[ -z "$REPO" ]]; then
+  echo "Usage: $0 <owner/repo>" >&2
+  exit 1
+fi
+
+echo "Applying branch protection to $REPO: main"
+
+# Basic PR requirements
+gh api -X PUT \
+  -H "Accept: application/vnd.github+json" \
+  repos/$REPO/branches/main/protection \
+  -f required_status_checks.strict=true \
+  --raw-field required_status_checks.contexts='["build","test","STDIO zh smoke"]' \
+  -f enforce_admins=true \
+  -f required_pull_request_reviews.dismiss_stale_reviews=true \
+  -f required_pull_request_reviews.require_code_owner_reviews=true \
+  -f required_pull_request_reviews.required_approving_review_count=1 \
+  -f restrictions=''
+
+echo "Restricting direct push to main (allow only GitHub Actions)"
+gh api -X PATCH \
+  -H "Accept: application/vnd.github+json" \
+  repos/$REPO/branches/main/protection/restrictions \
+  --raw-field users='[]' \
+  --raw-field teams='[]' \
+  --raw-field apps='["github-actions"]'
+
+echo "Done."
+
+


### PR DESCRIPTION
This PR introduces guardrails to prevent direct commits to main and adds Chinese STDIO smoke tests in CI.

What
 • Enforce PR-only workflow: CODEOWNERS, PR template
 • Educational workflow to block direct pushes to main (only GitHub Actions allowed)
 • Branch protection helper script (gh): status checks, code owner reviews, restricted pushes
 • README badge + docs for zh STDIO smoke tests

Why
 • Protect main from accidental direct pushes
 • Ensure review + passing checks before merge
 • Make Chinese STDIO path visible and continuously validated

How
 • CI: stdio-zh-smoke runs when WEATHER_API_KEY and GOOGLE_MAPS_API_KEY secrets exist
 • Run ‎`./scripts/setup-branch-protection.sh lis186/smart-weather-mcp-server` to apply branch protection via gh

Risks / Rollback
 • Low risk; only adds guardrails and docs
 • Revert PR via GitHub UI if needed